### PR TITLE
fix(login): render dev-login form client-only to avoid hydration mismatch

### DIFF
--- a/src/app/login/dev-login-form.tsx
+++ b/src/app/login/dev-login-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { signIn } from "next-auth/react";
 
 type WorkspaceOption = {
@@ -27,6 +27,12 @@ export function DevLoginForm({ workspaces }: { workspaces: WorkspaceOption[] }) 
   const [role, setRole] = useState<"admin" | "member" | "viewer">("member");
   const [workspaceId, setWorkspaceId] = useState(workspaces[0]?.id ?? "");
   const [loading, setLoading] = useState(false);
+
+  // Render client-only — password manager extensions inject extra DOM nodes
+  // into the input fields below, which causes a hydration mismatch on SSR.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
 
   async function handleLogin(
     loginEmail: string,


### PR DESCRIPTION
## Summary

Password-manager extensions (Bitwarden, 1Password, LastPass, Dashlane) inject autofill icons and fill buttons into the dev-login form's `<input>` fields after SSR but before React hydration. React flags this as a hydration mismatch on every page load of `/login` in development.

`suppressHydrationWarning` only covers attribute mismatches on a single element — it doesn't catch a new injected child node — so attributes-level suppression wasn't enough.

Gate the form behind a `useEffect`-mounted flag so it renders client-only. The form is dev-only (`isDev` gated in `page.tsx`), so SSR was never useful here.

## Test plan

- [x] Reload `/login` with a password-manager extension installed → no hydration warning in browser console.
- [x] Dev-login form still works after hydration (preset buttons, custom email form, workspace selector).
- [x] Production behavior unchanged — the form doesn't render in prod (`isDev && ...`).